### PR TITLE
feat(spicetify-creator): allow dist output in nested folder

### DIFF
--- a/packages/spicetify-creator/src/scripts.ts
+++ b/packages/spicetify-creator/src/scripts.ts
@@ -31,7 +31,7 @@ const build = async (watch: boolean, minify: boolean, outDirectory?: string) => 
 
   // Create outDirectory if it doesn't exists
   if (!fs.existsSync(outDirectory)){
-    fs.mkdirSync(outDirectory);
+    fs.mkdirSync(outDirectory, { recursive: true });
   }
 
   const esbuildOptions = {


### PR DESCRIPTION
Like the title says, this PR allows outputting the dist in a nested folder. For example `dist/app-name`.
I need this for one of my projects. (Well 'need' is a big word, but this is the easiest solution).