### PR TITLE
Add support for passing props to custom apps

### DIFF
--- a/packages/spicetify-creator/src/buildCustomApp.ts
+++ b/packages/spicetify-creator/src/buildCustomApp.ts
@@ -34,7 +34,8 @@ import App from \'${appPath.replace(/\\/g, "/")}\'
 import React from 'react';
 
 export default function render() {
-  return <App />;
+  const { location } = Spicetify.Platform.History;
+  return <App {...location.state.props} />;
 }
   `.trim())
 


### PR DESCRIPTION
This allows you to send a "props" field when pushing to the history state, which will be expanded and added to the custom app. 

e.g. 
```js
Spicetify.Platform.History.push({
      pathname: '/spurdle',
      state: {
        props: { URIs },
      },
    });
```

I modified locally in the node_modules for my Spurdle app, and works:
<img width="475" alt="image" src="https://user-images.githubusercontent.com/1565883/163310747-56a88d2d-a889-4704-8550-fef0f864c949.png">

Fixes #8

I had also considered just expanding `...location.state`, but it included some extra stuff that might not be desired. 
<img width="225" alt="image" src="https://user-images.githubusercontent.com/1565883/163310622-e6926a12-055d-4a90-9df8-f9db0214ca46.png">
