### PR TITLE
fix: use plugin-external-global for replacing imports

### DIFF
--- a/packages/spicetify-creator/package.json
+++ b/packages/spicetify-creator/package.json
@@ -17,6 +17,7 @@
     "chalk": "^4.1.2",
     "clean-css": "^5.2.4",
     "esbuild": "^0.14.13",
+    "esbuild-plugin-external-global": "^1.0.1",
     "esbuild-plugin-postcss2": "0.1.1",
     "glob": "^7.2.0",
     "minimist": "^1.2.5",

--- a/packages/spicetify-creator/src/buildCustomApp.ts
+++ b/packages/spicetify-creator/src/buildCustomApp.ts
@@ -60,18 +60,6 @@ export default function render() {
     console.log("Moving files out of folders...");
     extractFiles(outDirectory, true);
 
-    console.log("Adding react and react-dom...")
-    const jsFiles = await glob.sync(path.join(outDirectory, "/*(*.js)"));
-    jsFiles.forEach(jsFile => {
-      const data = fs.readFileSync(jsFile, 'utf-8').split("\n");
-      const appendAbove = data.findIndex((l) => l.includes(`if (typeof require !== "undefined")`))
-      if (appendAbove !== -1) {
-        data.splice(appendAbove, 0,        `if (x === "react") return Spicetify.React;`);
-        data.splice(appendAbove + 1, 0,    `if (x === "react-dom") return Spicetify.ReactDOM;`);
-        fs.writeFileSync(jsFile, data.join("\n")+"\n");
-      }
-    })
-
     console.log("Modifying index.js...")
     fs.appendFileSync(path.join(outDirectory, "index.js"), `const render=()=>${esbuildOptions.globalName}.default();\n`);
 

--- a/packages/spicetify-creator/src/buildExtension.ts
+++ b/packages/spicetify-creator/src/buildExtension.ts
@@ -47,15 +47,6 @@ import main from \'${appPath.replace(/\\/g, "/")}\'
   })
 
   const afterBundle = async () => {
-    console.log("Adding react and react-dom...")
-    const data = fs.readFileSync(compiledExtension, 'utf-8').split("\n");
-    const appendAbove = data.findIndex((l) => l.includes(`if (typeof require !== "undefined")`))
-    if (appendAbove !== -1) {
-      data.splice(appendAbove, 0,        `if (x === "react") return Spicetify.React;`);
-      data.splice(appendAbove + 1, 0,    `if (x === "react-dom") return Spicetify.ReactDOM;`);
-      fs.writeFileSync(compiledExtension, data.join("\n")+"\n");
-    }
-
     if (fs.existsSync(compiledExtensionCSS)) {
       console.log("Bundling css and js...");
       

--- a/packages/spicetify-creator/src/scripts.ts
+++ b/packages/spicetify-creator/src/scripts.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util'
 import { ICustomAppSettings, IExtensionSettings } from './helpers/models'
 import buildCustomApp from './buildCustomApp'
 import buildExtension from './buildExtension'
+import { externalGlobalPlugin } from 'esbuild-plugin-external-global'
 const postCssPlugin = require("esbuild-plugin-postcss2");
 const autoprefixer = require("autoprefixer");
 
@@ -46,6 +47,10 @@ const build = async (watch: boolean, minify: boolean, outDirectory?: string) => 
           generateScopedName: `[name]__[local]___[hash:base64:5]_${id}`
         },
       }),
+      externalGlobalPlugin({
+        'react': 'Spicetify.React',
+        'react-dom': 'Spicetify.ReactDOM',
+      })
     ],
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -539,6 +539,11 @@ esbuild-openbsd-64@0.14.47:
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz#309af806db561aa886c445344d1aacab850dbdc5"
   integrity sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==
 
+esbuild-plugin-external-global@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esbuild-plugin-external-global/-/esbuild-plugin-external-global-1.0.1.tgz#e3bba0e3a561f61b395bec0984a90ed0de06c4ce"
+  integrity sha512-NDzYHRoShpvLqNcrgV8ZQh61sMIFAry5KLTQV83BPG5iTXCCu7h72SCfJ97bW0GqtuqDD/1aqLbKinI/rNgUsg==
+
 esbuild-plugin-postcss2@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/esbuild-plugin-postcss2/-/esbuild-plugin-postcss2-0.1.1.tgz#f7d7964b26cb49f23f620ea437635aba654628f4"


### PR DESCRIPTION
previously react and react-dom imports were pointed to their corresponding Spicetify.<name> by post processing the bundled js.

Now it is done in a cleaner way with plugin-external-global