### PR TITLE
fix: wait for dynamic hooking of React

### DIFF
--- a/packages/spicetify-creator/src/buildCustomApp.ts
+++ b/packages/spicetify-creator/src/buildCustomApp.ts
@@ -66,6 +66,19 @@ export default function render() {
     console.log("Renaming index.css...")
     if (fs.existsSync(path.join(outDirectory, "index.css")))
       fs.renameSync(path.join(outDirectory, "index.css"), path.join(outDirectory, "style.css"))
+
+    // Account for dynamic hooking of React and ReactDOM
+    extensionsNewNames.map(e => path.basename(e)).map(extensionFile => {
+      const extensionFilePath = path.join(outDirectory, extensionFile);
+      fs.writeFileSync(extensionFilePath, `
+        (async function() {
+          while (!Spicetify.React || !Spicetify.ReactDOM) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+          ${fs.readFileSync(extensionFilePath, "utf-8")}
+        })();
+      `.trim());
+    });
     
     if (minify) {
       console.log("Minifying...");

--- a/packages/spicetify-creator/src/buildExtension.ts
+++ b/packages/spicetify-creator/src/buildExtension.ts
@@ -78,7 +78,7 @@ import main from \'${appPath.replace(/\\/g, "/")}\'
     }
 
     // Account for dynamic hooking of React and ReactDOM
-    fm.writeFileSync(compiledExtension, `
+    fs.writeFileSync(compiledExtension, `
       (async function() {
         while (!Spicetify.React || !Spicetify.ReactDOM) {
           await new Promise(resolve => setTimeout(resolve, 10));

--- a/packages/spicetify-creator/src/buildExtension.ts
+++ b/packages/spicetify-creator/src/buildExtension.ts
@@ -83,7 +83,7 @@ import main from \'${appPath.replace(/\\/g, "/")}\'
         while (!Spicetify.React || !Spicetify.ReactDOM) {
           await new Promise(resolve => setTimeout(resolve, 10));
         }
-        ${fs_1.default.readFileSync(compiledExtension, "utf-8")}
+        ${fs.readFileSync(compiledExtension, "utf-8")}
       })();`.trim());
 
     console.log(chalk.green('Build succeeded.'));

--- a/packages/spicetify-creator/src/buildExtension.ts
+++ b/packages/spicetify-creator/src/buildExtension.ts
@@ -77,6 +77,15 @@ import main from \'${appPath.replace(/\\/g, "/")}\'
       await minifyFile(compiledExtension);
     }
 
+    // Account for dynamic hooking of React and ReactDOM
+    fm.writeFileSync(compiledExtension, `
+      (async function() {
+        while (!Spicetify.React || !Spicetify.ReactDOM) {
+          await new Promise(resolve => setTimeout(resolve, 10));
+        }
+        ${fs_1.default.readFileSync(compiledExtension, "utf-8")}
+      })();`.trim());
+
     console.log(chalk.green('Build succeeded.'));
   }
 }

--- a/packages/spicetify-creator/src/buildExtension.ts
+++ b/packages/spicetify-creator/src/buildExtension.ts
@@ -72,11 +72,6 @@ import main from \'${appPath.replace(/\\/g, "/")}\'
       `.trim());
     }
 
-    if (minify) {
-      console.log("Minifying...");
-      await minifyFile(compiledExtension);
-    }
-
     // Account for dynamic hooking of React and ReactDOM
     fs.writeFileSync(compiledExtension, `
       (async function() {
@@ -84,7 +79,13 @@ import main from \'${appPath.replace(/\\/g, "/")}\'
           await new Promise(resolve => setTimeout(resolve, 10));
         }
         ${fs.readFileSync(compiledExtension, "utf-8")}
-      })();`.trim());
+      })();
+    `.trim());
+
+    if (minify) {
+      console.log("Minifying...");
+      await minifyFile(compiledExtension);
+    }
 
     console.log(chalk.green('Build succeeded.'));
   }


### PR DESCRIPTION
Latest version of Spicetify has moved React and ReactDOM hooks to webpack injection, which would not appear right after the client is launched.
This should solve the issue (and has worked for me) of extensions using Creator and getting into errors as `Spicetify.React` returns undefined.