### PR TITLE
fix(spicetify-creator) building custom apps with any pm and os

### DIFF
--- a/packages/spicetify-creator/src/buildCustomApp.ts
+++ b/packages/spicetify-creator/src/buildCustomApp.ts
@@ -6,7 +6,7 @@ import { ICustomAppManifest, ICustomAppSettings } from './helpers/models'
 import extractFiles from './helpers/extractFiles'
 import { minifyFolder } from './helpers/minify';
 import esbuild from "esbuild";
-import process from 'process';
+import os from 'os';
 
 export default async (settings: ICustomAppSettings, outDirectory: string, watch: boolean, esbuildOptions: any, minify: boolean, inDirectory: string) => {
   const extensions = glob.sync(`${inDirectory}/extensions/*(*.ts|*.tsx|*.js|*.jsx)`);
@@ -25,7 +25,7 @@ export default async (settings: ICustomAppSettings, outDirectory: string, watch:
   fs.writeFileSync(path.join(outDirectory, "manifest.json"), JSON.stringify(customAppManifest, null, 2))
 
   const appPath = path.resolve(glob.sync(`${inDirectory}/*(app.ts|app.tsx|app.js|app.jsx)`)[0]);
-  const tempFolder = path.join(path.dirname(process.argv[1]), `./temp/`);
+  const tempFolder = path.join(os.tmpdir(), "spicetify-creator");
   const indexPath = path.join(tempFolder,`index.jsx`);
 
   if (!fs.existsSync(tempFolder))

--- a/packages/spicetify-creator/src/buildExtension.ts
+++ b/packages/spicetify-creator/src/buildExtension.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { IExtensionSettings } from './helpers/models'
 import { minifyCSS, minifyFile } from './helpers/minify';
 import esbuild from "esbuild";
+import os from 'os';
 
 export default async (settings: IExtensionSettings, outDirectory: string, watch: boolean, esbuildOptions: any, minify: boolean, inDirectory: string) => {
   // const extension = path.join("./src/", "app.tsx")
@@ -13,7 +14,7 @@ export default async (settings: IExtensionSettings, outDirectory: string, watch:
   const compiledExtensionCSS = path.join(outDirectory, `${settings.nameId}.css`);
 
   const appPath = path.resolve(glob.sync(`${inDirectory}/*(app.ts|app.tsx|app.js|app.jsx)`)[0]);
-  const tempFolder = path.join(path.dirname(process.argv[1]), `./temp/`);
+  const tempFolder = path.join(os.tmpdir(), "spicetify-creator");
   const indexPath = path.join(tempFolder,`index.jsx`);
   
   if (!fs.existsSync(tempFolder))


### PR DESCRIPTION
1.0.16 doesn't build apps when using unix-based os and npm