### PR TITLE
fix(spicetify-creator): add PostCSS config loading support

### DIFF
--- a/packages/spicetify-creator/package.json
+++ b/packages/spicetify-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spicetify-creator",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Easily make Spicetify extensions and custom apps.",
   "bin": "./dist/index.js",
   "scripts": {
@@ -17,6 +17,7 @@
     "esbuild-plugin-postcss2": "0.1.1",
     "glob": "^7.2.0",
     "minimist": "^1.2.5",
+    "postcss-load-config": "^6.0.1",
     "uglify-js": "^3.15.1"
   },
   "files": [

--- a/packages/spicetify-creator/src/scripts.ts
+++ b/packages/spicetify-creator/src/scripts.ts
@@ -36,6 +36,14 @@ const build = async (watch: boolean, minify: boolean, outDirectory?: string, inD
     fs.mkdirSync(outDirectory, { recursive: true });
   }
 
+  // Load PostCSS config or fallback to autoprefixer
+  let postCSSPlugins = [autoprefixer];
+  try {
+    const postcssrc = require('postcss-load-config');
+    const { plugins } = await postcssrc({}, path.dirname(inDirectory));
+    postCSSPlugins = plugins;
+  } catch {}
+
   const esbuildOptions = {
     platform: 'browser',
     external: ['react', 'react-dom'],
@@ -43,7 +51,7 @@ const build = async (watch: boolean, minify: boolean, outDirectory?: string, inD
     globalName: id,
     plugins: [
       postCssPlugin.default({
-        plugins: [autoprefixer],
+        plugins: postCSSPlugins,
         modules: {
           generateScopedName: `[name]__[local]___[hash:base64:5]_${id}`
         },

--- a/packages/spicetify-creator/src/scripts.ts
+++ b/packages/spicetify-creator/src/scripts.ts
@@ -7,6 +7,7 @@ import buildExtension from './buildExtension'
 import { externalGlobalPlugin } from 'esbuild-plugin-external-global'
 const postCssPlugin = require("esbuild-plugin-postcss2");
 const autoprefixer = require("autoprefixer");
+const postcssrc = require('postcss-load-config');
 
 const exec = promisify(require('child_process').exec);
 
@@ -39,7 +40,6 @@ const build = async (watch: boolean, minify: boolean, outDirectory?: string, inD
   // Load PostCSS config or fallback to autoprefixer
   let postCSSPlugins = [autoprefixer];
   try {
-    const postcssrc = require('postcss-load-config');
     const { plugins } = await postcssrc({}, path.dirname(inDirectory));
     postCSSPlugins = plugins;
   } catch {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,6 +975,11 @@ less@^4.x:
     needle "^3.1.0"
     source-map "~0.6.0"
 
+lilconfig@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
+  integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
+
 loader-utils@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
@@ -1155,6 +1160,13 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+postcss-load-config@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-6.0.1.tgz#6fd7dcd8ae89badcf1b2d644489cbabf83aa8096"
+  integrity sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==
+  dependencies:
+    lilconfig "^3.1.1"
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
this adds tailwindcss 3/4 support by adding your own postcss config, while keeping it backwards compatible